### PR TITLE
chore: bump to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "backend_impl"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "async-std",
  "backend_api",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ic-fortune-wheel",
+  "version": "0.3.0",
   "scripts": {
     "build": "pnpm -r run build",
     "prebuild": "pnpm -r run prebuild",

--- a/src/backend/impl/Cargo.toml
+++ b/src/backend/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backend_impl"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.2.0",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -11,7 +11,7 @@ import tailwindcss from '@tailwindcss/vite';
 const dfxEnvList = dotenvConfig({ path: '../../.env' }).parsed || {};
 const DFX_NETWORK = dfxEnvList.DFX_NETWORK;
 
-const { version } = JSON.parse(readFileSync('./package.json').toString());
+const { version } = JSON.parse(readFileSync('../../package.json').toString());
 const lastCommitShortSha = execSync('git rev-parse --short HEAD')
   .toString()
   .trim();


### PR DESCRIPTION
Additionally, moves version number to the root `package.json` file