### PR TITLE
perf: cache modal images on extraction

### DIFF
--- a/src/frontend/src/components/ui/dialog.tsx
+++ b/src/frontend/src/components/ui/dialog.tsx
@@ -64,7 +64,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid max-h-full w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           className,
         )}
         onPointerDownOutside={e => {

--- a/src/frontend/src/hooks/use-wheel-prizes.ts
+++ b/src/frontend/src/hooks/use-wheel-prizes.ts
@@ -6,6 +6,7 @@ import { useWheelPrizeOrder } from '@/hooks/use-wheel-prize-order';
 import { useUpdateWheelAsset } from '@/hooks/use-update-wheel-asset';
 import { atom, Provider, useAtom } from 'jotai';
 import { toastError } from '@/lib/utils';
+import { cacheWheelModalImage } from '@/lib/wheel-prize';
 
 const FETCH_WHEEL_PRIZES_INTERVAL_MS = 10_000;
 
@@ -214,6 +215,9 @@ export const useWheelPrizes = (): UseWheelPrizesReturnType => {
     const prize = fetchedPrizes[index];
     if (prize) {
       setCurrentPrize({ prize, index });
+
+      // We don't need to wait for the image to be cached
+      cacheWheelModalImage(prize);
     }
   };
 

--- a/src/frontend/src/lib/wheel-prize.ts
+++ b/src/frontend/src/lib/wheel-prize.ts
@@ -26,3 +26,14 @@ export const mapPrizesToWheelData = <T extends WheelPrize>(
     };
   });
 };
+
+export const cacheWheelModalImage = async (wheelAsset: WheelPrize) => {
+  const modalImageUrl = wheelAssetUrl(wheelAsset.modal_image_path);
+  if (modalImageUrl) {
+    // All wheel images should have `Cache-Control` set to 1 week,
+    // so we can just pre-fetch them to avoid flickering when they're loaded.
+    await fetch(modalImageUrl, {
+      method: 'GET',
+    });
+  }
+};


### PR DESCRIPTION
Additionally, fixes the dialogs: now, if the content overflows the height of the screen, it can be scrolled